### PR TITLE
Serve the client over HTTPS via Caddy in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ coverage
 # Config
 .env
 config.toml
+
+# Caddy's local CA + issued certs (see Caddyfile's `storage` block)
+.caddy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,10 @@ Run from the repo root unless noted.
 pnpm start              # dev: client (vite --host) + server (cargo run) together
 pnpm run client:dev     # dev: client only
 pnpm run server:dev     # dev: server only (cargo run)
-pnpm run release        # prod: build client + `serve` on :8080, server in release
+pnpm run release        # prod: build client + Caddy (HTTPS) + server in release — requires a system `caddy`
 ```
+
+**Production serving is HTTPS via Caddy** (root `Caddyfile`): Caddy serves `client/dist` on :8080 and TLS-terminates the API on :8443, reverse-proxying to actix on 127.0.0.1:8100 (ports overridable via `WEB_FILE_BROWSER_CLIENT_PORT` / `WEB_FILE_BROWSER_API_PORT` / `WEB_FILE_BROWSER_UPSTREAM_PORT`). Certificates come from Caddy's internal CA (`local_certs` + on-demand issuance), so each browsing device must trust that CA's root once. Both halves must be HTTPS together because the client derives its API base URL from `location.protocol` — for a release build set `server_port = 8443` in `client/src/config.toml`; dev (`pnpm start`) bypasses Caddy entirely and keeps `server_port` = the actix port. Behind the proxy the source-IP gate sees only 127.0.0.1, so set `address = "127.0.0.1"` in `server/config.toml` to make the proxy the only network entry point.
 
 Client (run inside `client/`):
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,63 @@
+# Production front end for the Web File Browser (`pnpm run release`).
+#
+# Caddy terminates TLS for BOTH halves of the app:
+#
+#   browser ── https://<host>:8080 ──> Caddy ── static files ──> client/dist
+#   browser ── https://<host>:8443 ──> Caddy ── plain HTTP ────> actix on 127.0.0.1:8100
+#
+# Both must be HTTPS together: the client builds its API base URL from
+# `location.protocol` + `location.hostname` + `server_port` (client/src/lib/http.ts),
+# so an HTTPS page calls an HTTPS API on the same hostname. For a release
+# deployment, set `server_port = 8443` in client/src/config.toml before building
+# (dev keeps pointing straight at the actix port).
+#
+# Ports are overridable via environment variables:
+#   WEB_FILE_BROWSER_CLIENT_PORT    HTTPS port for the SPA            (default 8080)
+#   WEB_FILE_BROWSER_API_PORT       HTTPS port for the API            (default 8443)
+#   WEB_FILE_BROWSER_UPSTREAM_PORT  actix's own port (`port` in server/config.toml,
+#                                   default 8100)
+#
+# Note: the actix source-IP gate sees every proxied request as coming from
+# 127.0.0.1, so it no longer filters network clients. Bind actix to loopback
+# (`address = "127.0.0.1"` in server/config.toml) so this proxy is the only way
+# in from the network, and keep these listeners on a trusted LAN.
+
+{
+	# Issue certificates from Caddy's built-in local CA instead of a public ACME
+	# CA — this is a LAN deployment with no public domain. Each device that
+	# browses the app must trust that CA's root once:
+	#   - on this machine: `caddy trust` (or it is installed automatically when
+	#     Caddy has permission to do so)
+	#   - on other devices: import the root certificate from
+	#     $XDG_DATA_HOME/caddy/pki/authorities/local/root.crt
+	#     (~/.local/share/caddy/... by default; `caddy environment` prints the
+	#     exact data directory as XDG_DATA_HOME)
+	local_certs
+}
+
+# ---- Client: the built SPA, replacing `serve` ----
+https://:{$WEB_FILE_BROWSER_CLIENT_PORT:8080} {
+	# Mint a certificate for whatever name the browser used (LAN IP, mDNS name,
+	# localhost, ...) at handshake time, so no hostnames are hardcoded here.
+	tls internal {
+		on_demand
+	}
+
+	root * ./client/dist
+	encode zstd gzip
+
+	# SPA fallback: vue-router owns the path space (equivalent of `serve --single`).
+	try_files {path} /index.html
+	file_server
+}
+
+# ---- API: TLS in front of the Rust server ----
+https://:{$WEB_FILE_BROWSER_API_PORT:8443} {
+	tls internal {
+		on_demand
+	}
+
+	# The original Host header is passed through (Caddy's default), which the
+	# server's Host allowlist / DNS-rebinding guard relies on.
+	reverse_proxy 127.0.0.1:{$WEB_FILE_BROWSER_UPSTREAM_PORT:8100}
+}

--- a/Caddyfile
+++ b/Caddyfile
@@ -23,15 +23,22 @@
 # in from the network, and keep these listeners on a trusted LAN.
 
 {
+	# Keep the CA and issued certs in the repo (gitignored) rather than wherever
+	# $XDG_DATA_HOME happens to resolve to, so the CA — and therefore every
+	# device's one-time trust of it — survives regardless of which user/environment
+	# runs `pnpm run release`. Path is relative to Caddy's working directory, which
+	# is the repo root (see the `client:release` script in package.json).
+	storage file_system {
+		root ./.caddy
+	}
+
 	# Issue certificates from Caddy's built-in local CA instead of a public ACME
 	# CA — this is a LAN deployment with no public domain. Each device that
 	# browses the app must trust that CA's root once:
 	#   - on this machine: `caddy trust` (or it is installed automatically when
 	#     Caddy has permission to do so)
 	#   - on other devices: import the root certificate from
-	#     $XDG_DATA_HOME/caddy/pki/authorities/local/root.crt
-	#     (~/.local/share/caddy/... by default; `caddy environment` prints the
-	#     exact data directory as XDG_DATA_HOME)
+	#     ./.caddy/pki/authorities/local/root.crt
 	local_certs
 }
 

--- a/client/src/config.template.toml
+++ b/client/src/config.template.toml
@@ -1,2 +1,5 @@
-# The port to run the Web File Browser server on
+# The port the browser reaches the Web File Browser server's API on.
+# - dev (`pnpm start`): the server's own port (`port` in server/config.toml)
+# - release (`pnpm run release`): Caddy's HTTPS API port (8443 unless
+#   WEB_FILE_BROWSER_API_PORT overrides it), which proxies to the server
 server_port = 8100

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "client:dev": "cd client && pnpm start --host",
     "server:dev": "cd server && cargo run",
     "release": "concurrently --kill-others --names \"Release Client\",\"Release Server\" --prefix-colors blue,yellow \"pnpm run client:release\" \"pnpm run server:release\"",
-    "client:release": "cd client && pnpm run build && serve -l 8080 --single dist",
+    "client:release": "cd client && pnpm run build && cd .. && caddy run --config Caddyfile",
     "server:release": "cd server && cargo run -r"
   },
   "dependencies": {

--- a/server/config.template.toml
+++ b/server/config.template.toml
@@ -2,6 +2,10 @@
 log_level = "info"
 # The port to run the server on
 port = 8100
+# The interface to bind the server to. Defaults to all interfaces ("0.0.0.0").
+# When running behind the repo's TLS-terminating Caddyfile (`pnpm run release`),
+# bind to loopback so the proxy is the only way in from the network:
+# address = "127.0.0.1"
 # The absolute system path to the directory that will be the file browser root directory
 root_dir = "/my/files"
 # Networks (CIDR) or bare IPs whose clients are allowed through the source-IP

--- a/server/src/app_config.rs
+++ b/server/src/app_config.rs
@@ -17,6 +17,10 @@ pub struct AppConfig {
   /// Exact `Host` header values accepted (DNS-rebinding guard). When empty, only
   /// local hosts (localhost / loopback / private IP) are accepted.
   pub allowed_hosts: Vec<String>,
+  /// Interface the listener binds to. Defaults to all interfaces; set to
+  /// `127.0.0.1` when a TLS-terminating reverse proxy (e.g. the repo's
+  /// Caddyfile) should be the only way in from the network.
+  pub address: String,
   pub log_level: LevelFilter,
   pub nonalpha_pattern: Regex,
   pub port: u16,
@@ -59,6 +63,7 @@ impl AppConfig {
       allowed_cidrs: Self::parse_allowed_cidrs(settings.get::<Vec<String>>("allowed_cidrs").ok()),
       allowed_origins: settings.get::<Vec<String>>("allowed_origins").unwrap_or_default(),
       allowed_hosts: settings.get::<Vec<String>>("allowed_hosts").unwrap_or_default(),
+      address: settings.get_string("address").unwrap_or_else(|_| "0.0.0.0".into()),
       log_level: AppConfig::parse_app_log_level(&settings.get_string("log_level").unwrap_or("info".into())),
       nonalpha_pattern: Regex::new(r"^[^A-Za-z0-9]").unwrap(),
       port: settings.get_int("port").unwrap_or(9000) as u16,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -101,7 +101,7 @@ async fn main() -> io::Result<()> {
           .route("", web::head().to(index_route)),
       )
   })
-  .bind(("0.0.0.0", config.port))?
+  .bind((config.address.as_str(), config.port))?
   .run()
   .await
 }


### PR DESCRIPTION
Replace the `serve` npm package in the release flow with Caddy, which
terminates TLS for both halves of the app: it serves the built client on
:8080 (with the SPA fallback `serve --single` provided) and fronts the
API on :8443, reverse-proxying to actix on 127.0.0.1:8100. Both must be
HTTPS together because the client derives its API base URL from
`location.protocol`, so an HTTPS page calls an HTTPS API.

Certificates are minted on demand from Caddy's internal CA
(`local_certs`), so any LAN hostname or IP works without hardcoding
names; each browsing device trusts the CA root once. Ports are
overridable via WEB_FILE_BROWSER_CLIENT_PORT / _API_PORT /
_UPSTREAM_PORT.

The server gains an `address` bind option (default 0.0.0.0, unchanged)
so a release deployment can pin actix to loopback and make the proxy
the only network entry point — behind the proxy the source-IP gate only
ever sees 127.0.0.1. The dev flow is untouched: `pnpm start` still talks
to actix directly over HTTP on its configured port.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VMAy8TKRCGfj5dMFcbouKK